### PR TITLE
Return an error if file already exists on upload

### DIFF
--- a/lib/puppet_forge_server/backends/directory.rb
+++ b/lib/puppet_forge_server/backends/directory.rb
@@ -44,7 +44,9 @@ module PuppetForgeServer::Backends
     end
 
     def upload(file_data)
-      File.open(File.join(@module_dir, file_data[:filename]), 'w') do |f|
+      filename = File.join(@module_dir, file_data[:filename])
+      return false if File.exist?(filename)
+      File.open(filename, 'w') do |f|
         f.write(file_data[:tempfile].read)
       end
       true


### PR DESCRIPTION
This is a simple patch that will return an error when trying to upload a module that already exists on the `module_dir`.