### PR TITLE
Add links on module details

### DIFF
--- a/lib/puppet_forge_server/app/public/css/puppetlabs.css
+++ b/lib/puppet_forge_server/app/public/css/puppetlabs.css
@@ -240,7 +240,7 @@ li {
 .list.modules .summary {
   padding-right: 40px;
 }
-p.release-info {
+span.release-info {
   font-size: 0.9em;
   color: #6c6d6d;
 }
@@ -266,4 +266,9 @@ span.puppet {
 span.forge {
   color: #6B529A;
   float: right;
+}
+a.module-link {
+  margin-left: 10px;
+  color: #0095dd;
+  font-size: 0.9em;
 }

--- a/lib/puppet_forge_server/app/views/modules.haml
+++ b/lib/puppet_forge_server/app/views/modules.haml
@@ -22,4 +22,8 @@
         .col
           %h3= "#{element['owner']['username']}/#{element['name']}"
           %p= element['current_release']['metadata']['summary']
-          %p.release-info= "Version #{element['current_release']['metadata']['version']}"
+          %span.release-info= "Version #{element['current_release']['metadata']['version']}"
+          - if element['current_release']['metadata']['issues_url']
+            %a{:class => "module-link", :href => element['current_release']['metadata']['issues_url']}= "Report issues"
+          - if element['current_release']['metadata']['project_page']
+            %a{:class => "module-link", :href => element['current_release']['metadata']['project_page']}= "Project URL"


### PR DESCRIPTION
  This change create two new links :
    - Project page
    - Issues page

If those informations are not filled in the metadata.json, the coresponding links are not displayed

![screen shot 2015-04-27 at 18 41 26](https://cloud.githubusercontent.com/assets/739192/7352618/21db8c04-ed0d-11e4-8d34-5884ee58047c.png)
