### PR TITLE
Proxy fixes to prevent doubling of URL paths

### DIFF
--- a/lib/puppet_forge_server/api/v1/releases.rb
+++ b/lib/puppet_forge_server/api/v1/releases.rb
@@ -19,7 +19,7 @@ module PuppetForgeServer::Api::V1
     def get_releases(metadata)
       metadata.map do |element|
         {
-            :file => "/api/v1/files#{element[:path]}",
+            :file => "/api/v1/files#{element[:path].gsub(/^\/api\/v1\/files\//, '')}",
             :version => element[:metadata].version,
             :dependencies => element[:metadata].dependencies.map {|dep| [dep.name, dep.version_requirement]}
         }

--- a/lib/puppet_forge_server/api/v3/releases.rb
+++ b/lib/puppet_forge_server/api/v3/releases.rb
@@ -30,7 +30,7 @@ module PuppetForgeServer::Api::V3
             :metadata => element[:metadata].to_hash,
             :version => element[:metadata].version,
             :tags => element[:tags] ? element[:tags] : [element[:metadata].author, name],
-            :file_uri => "/v3/files#{element[:path]}",
+            :file_uri => "/v3/files#{element[:path].gsub(/^\/v3\/files\//, '')}",
             :file_md5 => element[:checksum]
         }
       end.version_sort_by { |r| r[:version] }

--- a/lib/puppet_forge_server/backends/proxy.rb
+++ b/lib/puppet_forge_server/backends/proxy.rb
@@ -63,7 +63,7 @@ module PuppetForgeServer::Backends
     end
 
     def download(relative_url)
-      @http_client.download(url(relative_url))
+      @http_client.download(url("#{@api_file_path}/#{relative_url}"))
     end
 
     def url(relative_url)

--- a/lib/puppet_forge_server/backends/proxy_v1.rb
+++ b/lib/puppet_forge_server/backends/proxy_v1.rb
@@ -26,6 +26,7 @@ module PuppetForgeServer::Backends
 
     def initialize(url, cache_dir, http_client = PuppetForgeServer::Http::HttpClient.new)
       super(url, cache_dir, http_client)
+      @api_file_path = '/api/v1/files'
     end
 
     def get_metadata(author, name, options = {})

--- a/lib/puppet_forge_server/backends/proxy_v3.rb
+++ b/lib/puppet_forge_server/backends/proxy_v3.rb
@@ -24,6 +24,7 @@ module PuppetForgeServer::Backends
 
     def initialize(url, cache_dir, http_client = PuppetForgeServer::Http::HttpClient.new)
       super(url, cache_dir, http_client)
+      @api_file_path = '/v3/files'
     end
 
     def get_metadata(author, name, options = {})


### PR DESCRIPTION
Encountered an issue with the proxy code where part of the download path as getting duplicated and failing when trying to download from Puppet Forge. If the file was in cache, then everything worked as expected. This was only when a new module was being pulled. I believe that this problem only occurred when a specific version was being pulled. If a version was not being specified (i.e. pull the latest version) then the code would work fine. 

The original code would read the metadata from Puppet Forge and would use the file_uri attribute which would already have /v3/files added to the path. Then in api/v3/release.rb the path would receive another /v3/files added, thus duplicating /v3/files. The result would be that when the file was attempted to be retrieved from Puppet Forge, the file would not be found because one of the /v3/files was being left on the filename causing a 404 to be returned. 

With this new code, v1 and v3 proxy code will strip off the version specific path from the filename and only add the version specific path back on when the file is attempting to be downloaded. 