### PR TITLE
Fix compatibility with librarian-puppet 2.2.1

### DIFF
--- a/lib/puppet_forge_server/api/v3/releases.rb
+++ b/lib/puppet_forge_server/api/v3/releases.rb
@@ -31,7 +31,8 @@ module PuppetForgeServer::Api::V3
             :version => element[:metadata].version,
             :tags => element[:tags] ? element[:tags] : [element[:metadata].author, name],
             :file_uri => "/v3/files#{element[:path]}",
-            :file_md5 => element[:checksum]
+            :file_md5 => element[:checksum],
+            :deleted_at => nil
         }
       end.uniq{|r| r[:version]}.sort_by { |r| Gem::Version.new(r[:version]) }
     end

--- a/lib/puppet_forge_server/api/v3/releases.rb
+++ b/lib/puppet_forge_server/api/v3/releases.rb
@@ -32,7 +32,7 @@ module PuppetForgeServer::Api::V3
             :tags => element[:tags] ? element[:tags] : [element[:metadata].author, name],
             :file_uri => "/v3/files#{element[:path]}",
             :file_md5 => element[:checksum],
-            :deleted_at => nil
+            :deleted_at => element[:deleted_at]
         }
       end.uniq{|r| r[:version]}.sort_by { |r| Gem::Version.new(r[:version]) }
     end

--- a/lib/puppet_forge_server/backends/proxy_v3.rb
+++ b/lib/puppet_forge_server/backends/proxy_v3.rb
@@ -78,7 +78,8 @@ module PuppetForgeServer::Backends
             :metadata => parse_dependencies(PuppetForgeServer::Models::Metadata.new(normalize_metadata(element['metadata']))),
             :checksum => element['file_md5'],
             :path => element['file_uri'],
-            :tags => (element['tags'] + (element['metadata']['tags'] ? element['metadata']['tags'] : [])).flatten.uniq
+            :tags => (element['tags'] + (element['metadata']['tags'] ? element['metadata']['tags'] : [])).flatten.uniq,
+            :deleted_at => element['deleted_at']
         }
       end
     end


### PR DESCRIPTION
librarian-puppet 2.2.1 calls #deleted_at for each release of a module.
See commit for more information:

  https://github.com/rodjek/librarian-puppet/commit/88efacffccdc26768542d7598f9721de2bc892cd

Without this fix, librarian-puppet crashes with this error:

```
/usr/local/share/gems/gems/her-0.6.8/lib/her/model/attributes.rb:76:in `method_missing': undefined method `deleted_at' for #<PuppetForge::V3::Release:0x00000001e8eff8> (NoMethodError)
	from /usr/local/share/gems/gems/activemodel-4.2.3/lib/active_model/attribute_methods.rb:433:in `method_missing'
	from /usr/local/share/gems/gems/puppet_forge-1.0.5/lib/her/lazy_accessors.rb:71:in `method_missing'
	from /usr/local/share/gems/gems/librarian-puppet-2.2.1/lib/librarian/puppet/source/forge/repo_v3.rb:21:in `block in get_versions'
	from /usr/local/share/gems/gems/librarian-puppet-2.2.1/lib/librarian/puppet/source/forge/repo_v3.rb:20:in `map'
	from /usr/local/share/gems/gems/librarian-puppet-2.2.1/lib/librarian/puppet/source/forge/repo_v3.rb:20:in `get_versions'
	from /usr/local/share/gems/gems/librarian-puppet-2.2.1/lib/librarian/puppet/source/forge/repo.rb:15:in `versions'
	from /usr/local/share/gems/gems/librarian-puppet-2.2.1/lib/librarian/puppet/source/forge/repo.rb:42:in `manifests'
	from /usr/local/share/gems/gems/librarian-puppet-2.2.1/lib/librarian/puppet/source/forge.rb:152:in `manifests'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/dependency.rb:155:in `cache_manifests!'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/dependency.rb:151:in `manifests'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/resolver/implementation.rb:159:in `block in resolving_dependency_map_find_manifests'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/resolver/implementation.rb:172:in `block (2 levels) in scope_resolving_dependency'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/resolver/implementation.rb:186:in `block in scope_checking_manifests'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/resolver/implementation.rb:230:in `scope'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/resolver/implementation.rb:185:in `scope_checking_manifests'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/resolver/implementation.rb:171:in `block in scope_resolving_dependency'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/resolver/implementation.rb:230:in `scope'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/resolver/implementation.rb:170:in `scope_resolving_dependency'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/resolver/implementation.rb:158:in `resolving_dependency_map_find_manifests'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/resolver/implementation.rb:65:in `do_resolve'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/resolver/implementation.rb:50:in `resolve'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/resolver.rb:23:in `resolve'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/action/resolve.rb:31:in `run'
	from /usr/local/share/gems/gems/librarian-puppet-2.2.1/lib/librarian/puppet/action/resolve.rb:10:in `run'
	from /usr/local/share/gems/gems/librarian-puppet-2.2.1/lib/librarian/puppet/cli.rb:104:in `resolve!'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/cli.rb:113:in `update'
	from /usr/local/share/gems/gems/librarian-puppet-2.2.1/lib/librarian/puppet/cli.rb:76:in `update'
	from /usr/local/share/gems/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /usr/local/share/gems/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /usr/local/share/gems/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /usr/local/share/gems/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/cli.rb:26:in `block (2 levels) in bin!'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/cli.rb:31:in `returning_status'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/cli.rb:26:in `block in bin!'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/cli.rb:47:in `with_environment'
	from /usr/local/share/gems/gems/librarianp-0.6.3/lib/librarian/cli.rb:26:in `bin!'
	from /usr/local/share/gems/gems/librarian-puppet-2.2.1/bin/librarian-puppet:7:in `<top (required)>'
	from /usr/local/bin/librarian-puppet:23:in `load'
	from /usr/local/bin/librarian-puppet:23:in `<main>'
```