### PR TITLE
Fix metadata.json regex for directory backend

### DIFF
--- a/lib/puppet_forge_server/backends/directory.rb
+++ b/lib/puppet_forge_server/backends/directory.rb
@@ -57,7 +57,7 @@ module PuppetForgeServer::Backends
 
     private
     def read_metadata(archive_path)
-      metadata_file = read_from_archive(archive_path, %r[[^/]+/metadata\.json$])
+      metadata_file = read_from_archive(archive_path, %r[^([^/]+/)?metadata\.json$])
       JSON.parse(metadata_file)
     rescue => error
       warn "Error reading from module archive #{archive_path}: #{error}"


### PR DESCRIPTION
Read metadata.json from the module root directory only 