### PR TITLE
#31 - only read files from tar object

### DIFF
--- a/lib/puppet_forge_server/utils/archiver.rb
+++ b/lib/puppet_forge_server/utils/archiver.rb
@@ -24,7 +24,7 @@ module PuppetForgeServer::Utils
       tar.rewind
       files = {}
       tar.each do |obj|
-        files[obj.full_name] = obj.read if obj.full_name =~ name_regex
+        files[obj.full_name] = obj.read if obj.file? && obj.full_name =~ name_regex
       end
       return files unless files.empty?
       raise "Given name #{name_regex} not found in #{archive}"


### PR DESCRIPTION
this fix the problem with some modules that include `PaxHeaders` and cause a unexpected token when reading the tar file.

Ref.: [Gem::Package::TarReader::Entry#file?](http://ruby-doc.org/stdlib-2.0.0/libdoc/rubygems/rdoc/Gem/Package/TarReader/Entry.html#method-i-file-3F)