### PR TITLE
Use summary field of module metadata if there's no description

### DIFF
--- a/lib/puppet_forge_server/api/v1/modules.rb
+++ b/lib/puppet_forge_server/api/v1/modules.rb
@@ -38,7 +38,7 @@ module PuppetForgeServer::Api::V1
             :author => author,
             :full_name => element.metadata.name.sub('-', '/'),
             :name => name,
-            :desc => element.metadata.description,
+            :desc => element.metadata.description || element.metadata.summary,
             :version => element.metadata.version,
             :project_url => element.metadata.project_page,
             :releases => releases_version(element.metadata),


### PR DESCRIPTION
Some modules on the puppetlabs forge (older ones?) have a 'summary', but not a 'description', and old puppet clients (3.4.3 in particular, but presumably others) are displeased with 'null' for their description.  This patch uses 'summary' if there is no description (which appears to be what puppet-library does/did).  