### PR TITLE
Add slug key to modules in API v3

### DIFF
--- a/lib/puppet_forge_server/api/v3/modules.rb
+++ b/lib/puppet_forge_server/api/v3/modules.rb
@@ -52,7 +52,7 @@ module PuppetForgeServer::Api::V3
 
     private
     def releases_version(metadata)
-      [{:version => metadata.version, :uri => "/v3/releases/#{metadata.name}-#{metadata.version}"}]
+      [{:version => metadata.version, :uri => "/v3/releases/#{metadata.name}-#{metadata.version}", :slug => "#{metadata.name}-#{metadata.version}"}]
     end
 
     def max_version(left, right)


### PR DESCRIPTION
Trying to fetch modules from puppet-forge-server using librarian-puppet v2.2.3 (with `no-use-v1-api`) and puppet_forge v2.2.1 ends with an error:

    [Librarian] Resolving puppetlabs-ntp (= 4.1.2) <http://forge.prs.internal>
    [Librarian]   Checking manifests
    /var/lib/gems/1.9.1/gems/puppet_forge-2.2.1/lib/puppet_forge/lazy_accessors.rb:62: stack level too deep (SystemStackError)

A response for `GET /v3/modules/puppetlabs-ntp` in public Puppet Forge returns following:

    {
      "uri": "/v3/releases/puppetlabs-ntp-4.1.2",
      "slug": "puppetlabs-ntp-4.1.2",
      "version": "4.1.2",
      "supported": false,
      "created_at": "2015-12-08 06:52:46 -0800",
      "deleted_at": null,
      "file_uri": "/v3/files/puppetlabs-ntp-4.1.2.tar.gz",
      "file_size": 26731
    }

While puppet-forge-server returns only `uri` and `version`. Adding `slug` seems to fix the issue for now, but it would be a good idea for puppet-forge-server to return more information, so as not to run into this problem again.