### PR TITLE
Fix incompatibility with versions containing '-' dash (e.g. pupetlabs-apache-0.5.0-rc1)

### DIFF
--- a/lib/puppet_forge_server/app/version3.rb
+++ b/lib/puppet_forge_server/app/version3.rb
@@ -40,7 +40,7 @@ module PuppetForgeServer::App
 
     get '/v3/releases/:module' do
       halt 404, json({:errors => ['404 Not found']}) unless params[:module]
-      author, name, version = params[:module].split '-'
+      author, name, version = params[:module].split('-',3)
       halt 400, json({:errors => ["'#{params[:module]}' is not a valid release slug"]}) unless author && name && version
       releases = releases(author, name, version)
       halt 404, json({:errors => ['404 Not found']}) unless releases


### PR DESCRIPTION
If a version retrieved from forge contains "dashes" (e.g. puppetlabs-apache-0.5.0-rc1), the split failes, and successiv calls to the backend return 404 