### PR TITLE
Allow running the app mounted on different paths on a server

### DIFF
--- a/lib/puppet_forge_server/app/views/layout.haml
+++ b/lib/puppet_forge_server/app/views/layout.haml
@@ -40,20 +40,20 @@
             %li.active
               %a{:href => 'https://forge.puppetlabs.com/', :target => 'official-puppet-forge'} Official Puppet Forge
             %li
-              %a{:href => '/upload'}
+              %a{:href => url('/upload')}
                 Upload Puppet Module
             %li
               %a{:href => 'https://github.com/unibet/puppet-forge-server', :target => 'puppet-forge-server-github'} Help
     %script{ :src => 'https://code.jquery.com/jquery-2.1.3.min.js' }
     .section#header
       .side-width.clearfix
-        %a{:href => '/'}
+        %a{:href => url('/')}
           #logo
             %img.logo{ :src => 'img/forge-logo.png', :height => 65}
             %span.logo.puppet= 'Puppet Forge'
             %span.logo.forge= 'Server'
         .top-search
-          %form{:action => '/modules', :method=>'get'}
+          %form{:action => url('/modules'), :method=>'get'}
             %input{ :type => 'search', :name=>'query', :placeholder=>'Search modules', :autofocus=>''}
             %input.search-btn{ :type=>'submit', :value=>'Find'}
             %span.search_error= ''

--- a/lib/puppet_forge_server/app/views/module.haml
+++ b/lib/puppet_forge_server/app/views/module.haml
@@ -47,7 +47,7 @@
               %ul.release-dependencies
                 - module_metadata['metadata']['dependencies'].each do |dep|
                   %li
-                    %a{:href => "/module?name=#{dep['name']}"}= dep['name']
+                    %a{:href => url("/module?name=#{dep['name']}")}= dep['name']
                     - if dep['version_requirement']
                       = "(#{dep['version_requirement']})"
         %section{:id => 'module-release-info'}

--- a/lib/puppet_forge_server/app/views/modules.haml
+++ b/lib/puppet_forge_server/app/views/modules.haml
@@ -20,7 +20,7 @@
     - modules.each do |element|
       %li{:class => element['private'] ? 'clearfix private' : 'clearfix'}
         .col
-          %a{:class => "h3", :href => "/module?name=#{element['current_release']['metadata']['name']}" }= "#{element['owner']['username']}/#{element['name']}"
+          %a{:class => "h3", :href => url("/module?name=#{element['current_release']['metadata']['name']}") }= "#{element['owner']['username']}/#{element['name']}"
           %p= element['current_release']['metadata']['summary']
           %span.release-info= "Version #{element['current_release']['metadata']['version']}"
           - if element['current_release']['metadata']['issues_url']

--- a/lib/puppet_forge_server/app/views/upload.haml
+++ b/lib/puppet_forge_server/app/views/upload.haml
@@ -36,7 +36,7 @@
   %div.code-block
     %pre
       :markdown
-        curl -F "file=@pkg/_&lt;name&gt;_-_&lt;version&gt;_.tar.gz" #{request.env['REQUEST_URI']}
+        curl -F "file=@pkg/_&lt;name&gt;_-_&lt;version&gt;_.tar.gz" #{request.env['rack.url_scheme']}://#{request.env['HTTP_HOST']}#{request.env['REQUEST_URI']}
 
   %span.search_error
     -if upload_status

--- a/lib/puppet_forge_server/app/views/upload.haml
+++ b/lib/puppet_forge_server/app/views/upload.haml
@@ -47,6 +47,6 @@
       -else
         Upload has failed. #{upload_status}
 
-  %form{:action => '/upload', :method=>'post', :enctype=>'multipart/form-data' }
+  %form{:action => url('/upload'), :method=>'post', :enctype=>'multipart/form-data' }
     %input{ :type => 'file', :name=>'file'}
     %input{ :type=>'submit', :value=>'Upload'}


### PR DESCRIPTION
This PR makes internal links take into account the server path where the app is running on a server, allowing you to run the app served out of a sub-path alongside other apps on the same server.

It also builds out the full URL for the displayed curl upload command.